### PR TITLE
sdm632-common/qcom-caf/Android: Switch HAL platform to MSM8996-R

### DIFF
--- a/qcom-caf/Android.mk
+++ b/qcom-caf/Android.mk
@@ -1,5 +1,5 @@
 LOCAL_PATH := $(call my-dir)
-HAL_PLATFORM := msm8996
+HAL_PLATFORM := msm8996-R
 HAL_PATH := hardware/qcom-caf/$(HAL_PLATFORM)
 
 include $(LOCAL_PATH)/display/Android.mk


### PR DESCRIPTION
* Arrow deprecated regular MSM8996 long ago, and have switched to
  MSM8996-R for it. Do the change accordingly.

Signed-off-by: Beru Hinode <windowz414@1337.lgbt>